### PR TITLE
Adding check_push_rights

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,48 @@
+# Reusable Workflows
+
+## Checking if ghcr push shall happen
+
+The workflow `check_ghcr_push.yml` can be used to check if a push of an image to `ghcr.io` shall happen or not.
+It is based on two assumptions:
+
+* We shall only push new images in two scenarios
+     * When we have pushed something to a branch.
+       This includes merge of pull requests.
+     * When we tag a commit
+* We shall only try to push to `ghcr.io` if we are working on an "official" KUKSA repository.
+  If running this workflow for a fork it shall return false, as the fork does not have credentials to
+  push to "official" KUKSA `ghcr.io` locations
+
+In general KUKSA build scripts
+
+
+tries to analyze if the run has sufficient credentials to be able
+to push docker containers to [Github pakages](https://github.com/features/packages) (ghcr.io).
+The analysis is performed by checking the context of the build, and if certain conditions are fulfilled it is assumed
+that credentials are present.
+
+The workflow can be used from other workflows like below.
+The example specifies that latest commit on main branch shall be used.
+Alternatively tags can be used to specify exactly which version of this workflow to use, like `check_ghcr_push.yml@3`
+
+```
+jobs:
+  check_ghcr_push:
+    uses: eclipse-kuksa/kuksa-actions/.github/workflows/check_ghcr_push.yml@main
+    secrets: inherit
+    
+  build-something:
+  
+    name: "Build something"
+    runs-on: self-hosted
+    needs: check_ghcr_push
+
+    steps:
+    - name: Log in to the Container registry
+      if: needs.check_ghcr_push.outputs.push == 'true'
+      uses: docker/login-action@v2
+      with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+```

--- a/.github/workflows/check_ghcr_push.yml
+++ b/.github/workflows/check_ghcr_push.yml
@@ -1,0 +1,38 @@
+on:
+  workflow_call:
+    outputs:
+      push:
+        description: "Push criteria fulfilled and likely in possession of ghcr.io tokens?"
+        value: ${{ jobs.check_ghcr_push.outputs.push }}
+
+# No concurrency group or cancel-in-progress here as this workflow is called from other workflows
+# so if you have a concurrency definition here it will be considered as a deadlock and job dismissed
+# The job below is also very fast, so no real need for cancel-in-progress
+
+jobs:
+  check_ghcr_push:
+    runs-on: ubuntu-latest
+
+    outputs:
+      push: ${{ steps.check-conditions.outputs.push }}
+
+    steps:
+    #Check if this is a push or tag for "root" repo, then we have access to secrets for pushing to GHCR. Forks do not
+    - name: Check conditions for upload
+      id: check-conditions
+      run: |
+          if [[ ("${{ github.event_name }}" == "push") || \
+                ("${{ github.ref_type }}" == "tag") ]] ; then
+            if [[ ("${{ github.repository }}" == "eclipse/kuksa.val") || \
+                  ("${{ github.repository }}" == "eclipse/kuksa.val.feeders") || \
+                  ("${{ github.repository_owner }}" == "eclipse-kuksa") ]] ; then
+              echo "We are pushing or tagging an official KUKSA repo, so pushing makes sense and we should have rights"
+              echo "push=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          fi
+          echo "Images shall only be uploaded for push/tag for official KUKSA repos"
+          echo "We are event ${{ github.event_name }} running in ${{ github.repository }}"
+          echo "In case this is a PR it is coming from ${{ github.event.pull_request.head.repo.full_name }} "
+          echo "push=false" >> $GITHUB_OUTPUT
+      shell: bash

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # kuksa-action
 
-Shared GH actions used in KUKSA CI
+Shared GH actions and [workflows](.github/workflows) used in KUKSA CI
 


### PR DESCRIPTION
Currently this workflow exists in both kuksa.val and kuksa.val.feeders. As we are to split repos we might get even more, and then it is good to have a common reusable location for it

Related to:

https://github.com/eclipse/kuksa.val/pull/680
https://github.com/eclipse/kuksa.val.feeders/pull/145

Those two PRs needs to be updated when this PR is merged.
We can also discuss release pattern for this repo, do we want to tag after every merged (significant) PR, or just when major backward incompatible changes are introduced. In this case, for now, users could easily use `main` as version identifier so no urgent need to tag.