### PR TITLE
Adding post-container-location

### DIFF
--- a/post-container-location/action.yml
+++ b/post-container-location/action.yml
@@ -1,0 +1,24 @@
+
+name: Post container location
+description: Post snippet to pull and run test container
+
+
+
+
+inputs:
+    image:
+      required: true
+      type: string
+      description: The OCI image
+ 
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        echo "## :hatching_chick: Moin!" >> $GITHUB_STEP_SUMMARY
+        echo "Something new is in the world" >> $GITHUB_STEP_SUMMARY 
+        echo -e "\nImages for testing temporarily available at \`${{ inputs.image }}\`" >> $GITHUB_STEP_SUMMARY
+        echo -e "\n\`\`\`\ndocker pull ${{ inputs.image }}\n\`\`\`" >> $GITHUB_STEP_SUMMARY
+        echo -e "\n\`\`\`\ndocker run --rm -it --net=host ${{ inputs.image }}\n\`\`\`" >> $GITHUB_STEP_SUMMARY
+      


### PR DESCRIPTION
Supposed to replace:

https://github.com/eclipse/kuksa.val/blob/master/.github/actions/post-container-location/action.yml
https://github.com/eclipse/kuksa.val.feeders/blob/main/.github/actions/post-container-location/action.yml

When we migrate components to own repositories!