### PR TITLE
Unique dash data

### DIFF
--- a/check-dash/action.yml
+++ b/check-dash/action.yml
@@ -23,11 +23,15 @@ runs:
         echo -e "Dash output: \n\`\`\` " >> $GITHUB_STEP_SUMMARY
         cat ${{ inputs.dashinput }}.out >> $GITHUB_STEP_SUMMARY
         echo -e "\n\`\`\`"
+        DASH_NAME_FULL=${{ inputs.dashinput }}
+        echo "DASH_NAME=${DASH_NAME_FULL##*/}" >> $GITHUB_ENV
     
     - name: "Archive dash artifacts"
       uses: actions/upload-artifact@v4
       with:
-        name: "Dash data"
+        # Name shall be unique to avoid conflicts if action is called multiple times
+        # from the same workflow
+        name: Dash Report - ${{env.DASH_NAME}}
         path: |
          ${{ inputs.dashinput }}
          ${{ inputs.dashinput }}.report


### PR DESCRIPTION
This is needed for use-case where you have aggregated workflows. An intended example is a Databroker release workflow where we want to trigger both databroker and databroker-cli workflows from the same workflow. With current setup that will fail as dash data will be overwritten. With this change (and making sure that different file names are used) there is no problem.

This change may theoretically cause backward incompatibilities if any action rely on the name of the dash artifact uploaded, but I assume no Kuksa component does that so suggest that this can be tagged as 2.6 and 2