### PR TITLE
Create Dash tickets

### DIFF
--- a/check-dash/README.md
+++ b/check-dash/README.md
@@ -3,21 +3,20 @@
 An action using [dash-license](https://github.com/eclipse/dash-licenses) to generate a license report and upload
 results.
 
-# How to use
+## How to use
 
 You need an input file that Dash can understand, then give it as input like below
 
-```
+```yaml
       - name: Dash license check
         uses: eclipse-kuksa/kuksa-actions/check-dash@2
         with:
           dashinput: ${{github.workspace}}/dash-databroker-deps
 ```
 
-
 The uploaded result will be a zip file containing an `*.out` file with result similar to this:
 
-```
+```yaml
 [main] INFO Querying Eclipse Foundation for license data for 217 items.
 [main] INFO Found 43 items.
 [main] INFO Querying ClearlyDefined for license data for 174 items.
@@ -26,3 +25,17 @@ The uploaded result will be a zip file containing an `*.out` file with result si
 ```
 
 More details are included in the `*.report` file. The input file is also uploaded.
+
+## Creating Eclipse IP tickets
+
+When you supply the optional input parameter `dashtoken`, this action will automatically create tickets for uncleared dependencies in Eclipse's [IP Due Diligence tracker](https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues).
+
+```yaml
+  - name: Dash license check
+    uses: eclipse-kuksa/kuksa-actions/check-dash@4
+    with:
+      dashinput: ${{github.workspace}}/dash-deps
+      dashtoken: ${{ secrets.MYDASHTOKEN }}
+```
+
+The tickets will be created for the `automotive.kuksa` project. You can override this by setting the `dashproject` input.

--- a/check-dash/action.yml
+++ b/check-dash/action.yml
@@ -12,9 +12,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Installing JVM, needed for Dash
-      shell: bash
-      run: sudo apt update && sudo apt-get install -y default-jre
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
     - name: "Run Dash"
       shell: bash
       run: |

--- a/check-dash/action.yml
+++ b/check-dash/action.yml
@@ -5,8 +5,14 @@ description: Check an input file via dash, and archive report. Print output in b
 inputs:
   dashinput:
     required: true
-    type: string
     description: "Dash Input file"
+  dashproject:
+    required: false
+    description: "Dash project, only required when creating tickets in Eclipse IP review system."
+    default: "automotive.kuksa"
+  dashtoken:
+    required: false
+    description: "Token for dash. If given, this action will create tickets in Eclipse IP rewiew system if required."
 
 
 runs:
@@ -20,7 +26,15 @@ runs:
       shell: bash
       run: |
         wget -O dash.jar "https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=LATEST"
-        java -jar dash.jar -summary ${{ inputs.dashinput }}.report  ${{ inputs.dashinput }} > ${{ inputs.dashinput }}.out 2>&1 || true
+        
+        if [[ -n "${{ inputs.dashtoken }}" ]]; then
+            echo -e "Dash token available. Will create tickets when required. \n " >> $GITHUB_STEP_SUMMARY
+            java -jar dash.jar -summary ${{ inputs.dashinput }}.report -project automotive.kuksa -token ${{ inputs.dashtoken }} -review  ${{ inputs.dashinput }} > ${{ inputs.dashinput }}.out 2>&1 || true
+        else
+            echo -e "Dash token not available. Will perform checking only. \n " >> $GITHUB_STEP_SUMMARY
+            java -jar dash.jar -summary ${{ inputs.dashinput }}.report  ${{ inputs.dashinput }} > ${{ inputs.dashinput }}.out 2>&1 || true
+        fi
+
         echo -e "Dash output: \n\`\`\` " >> $GITHUB_STEP_SUMMARY
         cat ${{ inputs.dashinput }}.out >> $GITHUB_STEP_SUMMARY
         echo -e "\n\`\`\`"


### PR DESCRIPTION
This updates the dash action, so that dash tickets can be automatically created if a secret is available.

This should be backwards compatible, but I still suggest tagging a new major version after merging this, just to be sure

If a secret is not given, or not available (in case of PRs from forks) it gracefully falls back to the "checking only"

Currently, even if i.e. the secret is wrong and the tool gives exceptions, the build step still is successful (this seesm more a coincidence, but I think it is good for introducing, until we feel more confident about  this. Error messages/Excpetions can still be seen in the steps summary)

Also, Java installation is much faster now as the "apt install" has been replace with an action that uses a cached install

A test repo/various test runs can be seen here https://github.com/SebastianSchildt/dashtest/actions