### PR TITLE
Add check-markdown

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,7 +28,7 @@ Alternatively tags can be used to specify exactly which version of this workflow
 ```
 jobs:
   check_ghcr_push:
-    uses: eclipse-kuksa/kuksa-actions/.github/workflows/check_ghcr_push.yml@main
+    uses: eclipse-kuksa/kuksa-actions/.github/workflows/check_ghcr_push.yml@4
     secrets: inherit
     
   build-something:

--- a/check-dash/README.md
+++ b/check-dash/README.md
@@ -9,7 +9,7 @@ You need an input file that Dash can understand, then give it as input like belo
 
 ```yaml
       - name: Dash license check
-        uses: eclipse-kuksa/kuksa-actions/check-dash@2
+        uses: eclipse-kuksa/kuksa-actions/check-dash@4
         with:
           dashinput: ${{github.workspace}}/dash-databroker-deps
 ```

--- a/check-markdown/README.md
+++ b/check-markdown/README.md
@@ -1,0 +1,21 @@
+# Check Markdown
+
+An action using [markdown-link-check](https://github.com/tcort/markdown-link-check) to check that all links
+in markdown (`*.md`) files are functional.
+
+## How to use
+
+An example on how to use this action to check all `*.md` files in a repository is shown below.
+
+```yaml
+  check-doc-links:
+    name: Check links in markdown
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: eclipse-kuksa/kuksa-actions/check-markdown@4
+
+```
+
+

--- a/check-markdown/action.yml
+++ b/check-markdown/action.yml
@@ -1,0 +1,15 @@
+
+name: Checking Markdown
+description: Check if links in markdown files are functional
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+
+    - name: Install and run npm
+      shell: bash
+      run: |
+        npm install -g markdown-link-check
+        markdown-link-check --version
+        find . -name \*.md  -print0  | xargs -0 -n1 markdown-link-check -q -a 403,200,404

--- a/spdx/README.md
+++ b/spdx/README.md
@@ -10,7 +10,7 @@ that files modified in a Pull Request has an SPDX license identifier.
 
 It shall be possible to use this action from other repositories by referencing:
 
-`- uses: eclipse-kuksa/kuksa-actions/spdx@2`
+`- uses: eclipse-kuksa/kuksa-actions/spdx@4`
 
 If you accept multiple licenses it can be specified like:
 


### PR DESCRIPTION
This commit introduces an action based on the markdown check in release process for:

https://github.com/eclipse-kuksa/kuksa-databroker/wiki/Release-Process#checking-links

Intention is to run it on each PR, a draft PR exist at https://github.com/eclipse-kuksa/kuksa-databroker/pull/35 but it will be updated when this one is merged and tagged as 4.1

Also updating doc to use recent version in examples