### PR TITLE
Include 404, exclude #

### DIFF
--- a/check-markdown/action.yml
+++ b/check-markdown/action.yml
@@ -12,4 +12,4 @@ runs:
       run: |
         npm install -g markdown-link-check
         markdown-link-check --version
-        find . -name \*.md  -print0  | xargs -0 -n1 markdown-link-check -q -a 403,200,404
+        find . -name \*.md  -print0  | xargs -0 -n1 markdown-link-check -c $GITHUB_ACTION_PATH/config.json -a 403,200

--- a/check-markdown/config.json
+++ b/check-markdown/config.json
@@ -1,0 +1,7 @@
+{
+    "ignorePatterns": [
+      {
+        "pattern": "^#"
+      }
+    ]
+}


### PR DESCRIPTION
Disabling checks on internal links as [framework](https://github.com/tcort/markdown-link-check) is not really stable there yet. 
Then we can "enable" 404 errors as we do not any longer get any false positives for internal links.
Also giving a bit more of output so you can see which files that are checked/omitted.

This has been tested with Databroker and there it works without problems
