### PR TITLE
Address bug in check-markdown-link

### DIFF
--- a/check-markdown/config.json
+++ b/check-markdown/config.json
@@ -2,6 +2,9 @@
     "ignorePatterns": [
       {
         "pattern": "^#"
+      },
+      {
+        "pattern": "%"
       }
     ]
 }


### PR DESCRIPTION
It currently gives an error for links containing %2F, like:

https://github.com/eclipse-kuksa/kuksa-python-sdk/pkgs/container/kuksa-python-sdk%2Fkuksa-client

Probably same error as reported in https://github.com/tcort/markdown-link-check/issues/264

Proposed workaround is to exclude links with % from check