### PR TITLE
Don't check http://localhost links in markdown

### DIFF
--- a/check-markdown/config.json
+++ b/check-markdown/config.json
@@ -5,6 +5,9 @@
       },
       {
         "pattern": "%"
+      },
+      {
+        "pattern": "^http://localhost"
       }
     ]
 }


### PR DESCRIPTION
When referencing local services, such as the Jaeger UI, the markdown documentations refers to links in the style of `http://localhost`, which the markdown checker tries to validate by default.

This PR disables the check for localhost links in markdown files.