### PR TITLE
backport 8524ffc from upstream: fix: allow whitespace character SPDX

### DIFF
--- a/spdx/verify-spdx-headers
+++ b/spdx/verify-spdx-headers
@@ -7,7 +7,7 @@
 import os
 import re
 
-SLUG = re.compile('[a-zA-Z0-9.-]+')
+SLUG = re.compile('[- a-zA-Z0-9.]+')
 SPDX = re.compile(rf'SPDX-License-Identifier:\s+({SLUG.pattern})')
 
 class Language:


### PR DESCRIPTION
This also allows for SPDX identifiers such as

"a and b" or "a or b"

as it uses whitespaces correctly. For a correct run see https://github.com/COVESA/Open1722/actions/runs/14588352450/job/40917908247?pr=92